### PR TITLE
Security: Fix Next.js CVE-2025-55184, CVE-2025-55183, CVE-2025-67779

### DIFF
--- a/fix_progress.log
+++ b/fix_progress.log
@@ -1,0 +1,396 @@
+[0;34m[INFO][0m Creating branch: fix/nextjs-cve-20251216
+Switched to a new branch 'fix/nextjs-cve-20251216'
+[0;32m✅ [SUCCESS][0m Created branch: fix/nextjs-cve-20251216
+[0;34m[INFO][0m Running npx fix-react2shell-next --fix...
+
+[1mfix-react2shell-next[0m[2m - Next.js vulnerability scanner
+[0m
+[2mChecking for 4 known vulnerabilities:
+[0m
+[2m  - [0m[31mCVE-2025-66478[0m[2m (critical): Remote code execution via crafted RSC payload[0m
+[2m  - [0m[33mCVE-2025-55184[0m[2m (high): DoS via malicious HTTP request causing server to hang and consume CPU[0m
+[2m  - [0m[36mCVE-2025-55183[0m[2m (medium): Compiled Server Action source code can be exposed via malicious request[0m
+[2m  - [0m[33mCVE-2025-67779[0m[2m (high): Incomplete fix for CVE-2025-55184 DoS via malicious RSC payload causing infinite loop[0m
+
+[2mFound 1 package.json file(s)
+[0m
+[31mFound 1 vulnerable file(s):
+[0m
+[33m  package.json[0m
+[2m     next: [0m[31m^13.4.4[0m[2m -> [0m[32m14.2.35[0m[35m [CVE-2025-55184, CVE-2025-67779][0m
+[2m        Next.js 13.x must upgrade to 14.2.34 or later to fix this vulnerability.[0m
+
+[36m
+Applying fixes...
+[0m
+[32m   Updated package.json[0m
+[36m
+Installing dependencies...
+[0m
+[2m. (npm)[0m
+[2m
+$ npm install
+[0m
+npm error code 1
+npm error path /Users/hark/ssw/automation/nextjs-cve-scanner/repos_temp/llama-link/node_modules/better-sqlite3
+npm error command failed
+npm error command sh -c prebuild-install || node-gyp rebuild --release
+npm error TOUCH ba23eeee118cd63e16015df367567cb043fed872.intermediate
+npm error   ACTION deps_sqlite3_gyp_locate_sqlite3_target_copy_builtin_sqlite3 ba23eeee118cd63e16015df367567cb043fed872.intermediate
+npm error   TOUCH Release/obj.target/deps/locate_sqlite3.stamp
+npm error   CC(target) Release/obj.target/sqlite3/gen/sqlite3/sqlite3.o
+npm error   LIBTOOL-STATIC Release/sqlite3.a
+npm error   CXX(target) Release/obj.target/better_sqlite3/src/better_sqlite3.o
+npm error rm ba23eeee118cd63e16015df367567cb043fed872.intermediate
+npm error (node:41317) [DEP0176] DeprecationWarning: fs.R_OK is deprecated, use fs.constants.R_OK instead
+npm error (Use `node --trace-deprecation ...` to show where the warning was created)
+npm error prebuild-install warn install No prebuilt binaries found (target=24.12.0 runtime=node arch=arm64 libc= platform=darwin)
+npm error gyp info it worked if it ends with ok
+npm error gyp info using node-gyp@11.4.2
+npm error gyp info using node@24.12.0 | darwin | arm64
+npm error gyp info find Python using Python version 3.10.19 found at "/Users/hark/.pyenv/versions/3.10.19/bin/python3"
+npm error gyp info spawn /Users/hark/.pyenv/versions/3.10.19/bin/python3
+npm error gyp info spawn args [
+npm error gyp info spawn args '/Users/hark/.nvm/versions/node/v24.12.0/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp_main.py',
+npm error gyp info spawn args 'binding.gyp',
+npm error gyp info spawn args '-f',
+npm error gyp info spawn args 'make',
+npm error gyp info spawn args '-I',
+npm error gyp info spawn args '/Users/hark/ssw/automation/nextjs-cve-scanner/repos_temp/llama-link/node_modules/better-sqlite3/build/config.gypi',
+npm error gyp info spawn args '-I',
+npm error gyp info spawn args '/Users/hark/.nvm/versions/node/v24.12.0/lib/node_modules/npm/node_modules/node-gyp/addon.gypi',
+npm error gyp info spawn args '-I',
+npm error gyp info spawn args '/Users/hark/Library/Caches/node-gyp/24.12.0/include/node/common.gypi',
+npm error gyp info spawn args '-Dlibrary=shared_library',
+npm error gyp info spawn args '-Dvisibility=default',
+npm error gyp info spawn args '-Dnode_root_dir=/Users/hark/Library/Caches/node-gyp/24.12.0',
+npm error gyp info spawn args '-Dnode_gyp_dir=/Users/hark/.nvm/versions/node/v24.12.0/lib/node_modules/npm/node_modules/node-gyp',
+npm error gyp info spawn args '-Dnode_lib_file=/Users/hark/Library/Caches/node-gyp/24.12.0/<(target_arch)/node.lib',
+npm error gyp info spawn args '-Dmodule_root_dir=/Users/hark/ssw/automation/nextjs-cve-scanner/repos_temp/llama-link/node_modules/better-sqlite3',
+npm error gyp info spawn args '-Dnode_engine=v8',
+npm error gyp info spawn args '--depth=.',
+npm error gyp info spawn args '--no-parallel',
+npm error gyp info spawn args '--generator-output',
+npm error gyp info spawn args 'build',
+npm error gyp info spawn args '-Goutput_dir=.'
+npm error gyp info spawn args ]
+npm error gyp info spawn make
+npm error gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
+npm error In file included from ../src/better_sqlite3.cpp:4:
+npm error In file included from ./src/better_sqlite3.lzz:11:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/node.h:74:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8.h:23:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/cppgc/common.h:8:
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8config.h:13:2: error: "C++20 or later required."
+npm error    13 | #error "C++20 or later required."
+npm error       |  ^
+npm error In file included from ../src/better_sqlite3.cpp:4:
+npm error In file included from ./src/better_sqlite3.lzz:11:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/node.h:74:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8.h:24:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-array-buffer.h:12:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-local-handle.h:13:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-handle-base.h:8:
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-internal.h:1256:37: error: a non-type template parameter cannot have type 'ExternalPointerTagRange' (aka 'TagRange<ExternalPointerTag>') before C++20
+npm error  1256 |   template <ExternalPointerTagRange tag_range>
+npm error       |                                     ^
+npm error In file included from ../src/better_sqlite3.cpp:4:
+npm error In file included from ./src/better_sqlite3.lzz:11:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/node.h:74:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8.h:24:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-array-buffer.h:12:
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-local-handle.h:280:5: error: unknown type name 'requires'
+npm error   280 |     requires std::is_base_of_v<T, S>
+npm error       |     ^
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-local-handle.h:280:19: error: non-friend class member 'is_base_of_v' cannot have a qualified name
+npm error   280 |     requires std::is_base_of_v<T, S>
+npm error       |              ~~~~~^
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-local-handle.h:280:19: error: member 'is_base_of_v' declared as a template
+npm error   279 |   template <class S>
+npm error       |   ~~~~~~~~~~~~~~~~~~
+npm error   280 |     requires std::is_base_of_v<T, S>
+npm error       |                   ^
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-local-handle.h:280:19: error: variable template partial specialization of 'is_base_of_v' not in a namespace enclosing '__1'
+npm error /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__type_traits/is_base_of.h:27:50: note: explicitly specialized declaration is here
+npm error    27 | _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_base_of_v = __is_base_of(_Bp, _Dp);
+npm error       |                                                  ^
+npm error In file included from ../src/better_sqlite3.cpp:4:
+npm error In file included from ./src/better_sqlite3.lzz:11:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/node.h:74:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8.h:24:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-array-buffer.h:12:
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-local-handle.h:280:37: error: expected ';' at end of declaration list
+npm error   280 |     requires std::is_base_of_v<T, S>
+npm error       |                                     ^
+npm error       |                                     ;
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-local-handle.h:645:5: error: unknown type name 'requires'
+npm error   645 |     requires std::is_base_of_v<T, S>
+npm error       |     ^
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-local-handle.h:645:19: error: non-friend class member 'is_base_of_v' cannot have a qualified name
+npm error   645 |     requires std::is_base_of_v<T, S>
+npm error       |              ~~~~~^
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-local-handle.h:645:19: error: member 'is_base_of_v' declared as a template
+npm error   644 |   template <class S>
+npm error       |   ~~~~~~~~~~~~~~~~~~
+npm error   645 |     requires std::is_base_of_v<T, S>
+npm error       |                   ^
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-local-handle.h:645:19: error: variable template partial specialization of 'is_base_of_v' not in a namespace enclosing '__1'
+npm error /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__type_traits/is_base_of.h:27:50: note: explicitly specialized declaration is here
+npm error    27 | _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_base_of_v = __is_base_of(_Bp, _Dp);
+npm error       |                                                  ^
+npm error In file included from ../src/better_sqlite3.cpp:4:
+npm error In file included from ./src/better_sqlite3.lzz:11:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/node.h:74:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8.h:24:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-array-buffer.h:12:
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-local-handle.h:645:37: error: expected ';' at end of declaration list
+npm error   645 |     requires std::is_base_of_v<T, S>
+npm error       |                                     ^
+npm error       |                                     ;
+npm error In file included from ../src/better_sqlite3.cpp:4:
+npm error In file included from ./src/better_sqlite3.lzz:11:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/node.h:74:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8.h:24:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-array-buffer.h:13:
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-memory-span.h:45:28: error: no member named 'ranges' in namespace 'std'
+npm error    45 | inline constexpr bool std::ranges::enable_view<v8::MemorySpan<T>> = true;
+npm error       |                       ~~~~~^
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-memory-span.h:47:28: error: no member named 'ranges' in namespace 'std'
+npm error    47 | inline constexpr bool std::ranges::enable_borrowed_range<v8::MemorySpan<T>> =
+npm error       |                       ~~~~~^
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-memory-span.h:168:35: error: no type named 'contiguous_iterator_tag' in namespace 'std'; did you mean 'output_iterator_tag'?
+npm error   168 |     using iterator_concept = std::contiguous_iterator_tag;
+npm error       |                              ~~~~~^~~~~~~~~~~~~~~~~~~~~~~
+npm error       |                                   output_iterator_tag
+npm error /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__iterator/iterator_traits.h:70:29: note: 'output_iterator_tag' declared here
+npm error    70 | struct _LIBCPP_TEMPLATE_VIS output_iterator_tag {};
+npm error       |                             ^
+npm error In file included from ../src/better_sqlite3.cpp:4:
+npm error In file included from ./src/better_sqlite3.lzz:11:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/node.h:74:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8.h:24:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-array-buffer.h:14:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-object.h:10:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-maybe.h:11:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/cppgc/internal/conditional-stack-allocated.h:10:
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/cppgc/macros.h:51:1: error: unknown type name 'concept'
+npm error    51 | concept IsStackAllocatedType =
+npm error       | ^
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/cppgc/macros.h:52:5: error: use of undeclared identifier 'requires'
+npm error    52 |     requires { typename T::IsStackAllocatedTypeMarker; };
+npm error       |     ^
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/cppgc/macros.h:52:13: error: expected ';' after top level declarator
+npm error    52 |     requires { typename T::IsStackAllocatedTypeMarker; };
+npm error       |             ^
+npm error       |             ;
+npm error In file included from ../src/better_sqlite3.cpp:4:
+npm error In file included from ./src/better_sqlite3.lzz:11:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/node.h:74:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8.h:24:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-array-buffer.h:14:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-object.h:10:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-maybe.h:11:
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/cppgc/internal/conditional-stack-allocated.h:22:1: error: unknown type name 'concept'
+npm error    22 | concept RequiresStackAllocated =
+npm error       | ^
+npm error fatal error: too many errors emitted, stopping now [-ferror-limit=]
+npm error 20 errors generated.
+npm error make: *** [Release/obj.target/better_sqlite3/src/better_sqlite3.o] Error 1
+npm error gyp ERR! build error 
+npm error gyp ERR! stack Error: `make` failed with exit code: 2
+npm error gyp ERR! stack at ChildProcess.<anonymous> (/Users/hark/.nvm/versions/node/v24.12.0/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:219:23)
+npm error gyp ERR! System Darwin 25.1.0
+npm error gyp ERR! command "/Users/hark/.nvm/versions/node/v24.12.0/bin/node" "/Users/hark/.nvm/versions/node/v24.12.0/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild" "--release"
+npm error gyp ERR! cwd /Users/hark/ssw/automation/nextjs-cve-scanner/repos_temp/llama-link/node_modules/better-sqlite3
+npm error gyp ERR! node -v v24.12.0
+npm error gyp ERR! node-gyp -v v11.4.2
+npm error gyp ERR! not ok
+npm error A complete log of this run can be found in: /Users/hark/.npm/_logs/2025-12-16T03_04_12_485Z-debug-0.log
+[33m
+Some install commands had issues.[0m
+[2m   The package.json files have been updated.[0m
+[2m   Please run install commands manually in the affected directories.
+[0m
+[0;32m✅ [SUCCESS][0m Fix command completed - vulnerabilities found and fixed
+[0;34m[INFO][0m Updating lockfiles for modified packages...
+[0;34m[INFO][0m   Found modified package.json in: .
+[0;34m[INFO][0m Processing directory: .
+[0;34m[INFO][0m   Detected package-lock.json in ., running npm install...
+npm error code 1
+npm error path /Users/hark/ssw/automation/nextjs-cve-scanner/repos_temp/llama-link/node_modules/better-sqlite3
+npm error command failed
+npm error command sh -c prebuild-install || node-gyp rebuild --release
+npm error TOUCH ba23eeee118cd63e16015df367567cb043fed872.intermediate
+npm error   ACTION deps_sqlite3_gyp_locate_sqlite3_target_copy_builtin_sqlite3 ba23eeee118cd63e16015df367567cb043fed872.intermediate
+npm error   TOUCH Release/obj.target/deps/locate_sqlite3.stamp
+npm error   CC(target) Release/obj.target/sqlite3/gen/sqlite3/sqlite3.o
+npm error   LIBTOOL-STATIC Release/sqlite3.a
+npm error   CXX(target) Release/obj.target/better_sqlite3/src/better_sqlite3.o
+npm error rm ba23eeee118cd63e16015df367567cb043fed872.intermediate
+npm error (node:42159) [DEP0176] DeprecationWarning: fs.R_OK is deprecated, use fs.constants.R_OK instead
+npm error (Use `node --trace-deprecation ...` to show where the warning was created)
+npm error prebuild-install warn install No prebuilt binaries found (target=24.12.0 runtime=node arch=arm64 libc= platform=darwin)
+npm error gyp info it worked if it ends with ok
+npm error gyp info using node-gyp@11.4.2
+npm error gyp info using node@24.12.0 | darwin | arm64
+npm error gyp info find Python using Python version 3.10.19 found at "/Users/hark/.pyenv/versions/3.10.19/bin/python3"
+npm error gyp info spawn /Users/hark/.pyenv/versions/3.10.19/bin/python3
+npm error gyp info spawn args [
+npm error gyp info spawn args '/Users/hark/.nvm/versions/node/v24.12.0/lib/node_modules/npm/node_modules/node-gyp/gyp/gyp_main.py',
+npm error gyp info spawn args 'binding.gyp',
+npm error gyp info spawn args '-f',
+npm error gyp info spawn args 'make',
+npm error gyp info spawn args '-I',
+npm error gyp info spawn args '/Users/hark/ssw/automation/nextjs-cve-scanner/repos_temp/llama-link/node_modules/better-sqlite3/build/config.gypi',
+npm error gyp info spawn args '-I',
+npm error gyp info spawn args '/Users/hark/.nvm/versions/node/v24.12.0/lib/node_modules/npm/node_modules/node-gyp/addon.gypi',
+npm error gyp info spawn args '-I',
+npm error gyp info spawn args '/Users/hark/Library/Caches/node-gyp/24.12.0/include/node/common.gypi',
+npm error gyp info spawn args '-Dlibrary=shared_library',
+npm error gyp info spawn args '-Dvisibility=default',
+npm error gyp info spawn args '-Dnode_root_dir=/Users/hark/Library/Caches/node-gyp/24.12.0',
+npm error gyp info spawn args '-Dnode_gyp_dir=/Users/hark/.nvm/versions/node/v24.12.0/lib/node_modules/npm/node_modules/node-gyp',
+npm error gyp info spawn args '-Dnode_lib_file=/Users/hark/Library/Caches/node-gyp/24.12.0/<(target_arch)/node.lib',
+npm error gyp info spawn args '-Dmodule_root_dir=/Users/hark/ssw/automation/nextjs-cve-scanner/repos_temp/llama-link/node_modules/better-sqlite3',
+npm error gyp info spawn args '-Dnode_engine=v8',
+npm error gyp info spawn args '--depth=.',
+npm error gyp info spawn args '--no-parallel',
+npm error gyp info spawn args '--generator-output',
+npm error gyp info spawn args 'build',
+npm error gyp info spawn args '-Goutput_dir=.'
+npm error gyp info spawn args ]
+npm error gyp info spawn make
+npm error gyp info spawn args [ 'BUILDTYPE=Release', '-C', 'build' ]
+npm error In file included from ../src/better_sqlite3.cpp:4:
+npm error In file included from ./src/better_sqlite3.lzz:11:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/node.h:74:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8.h:23:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/cppgc/common.h:8:
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8config.h:13:2: error: "C++20 or later required."
+npm error    13 | #error "C++20 or later required."
+npm error       |  ^
+npm error In file included from ../src/better_sqlite3.cpp:4:
+npm error In file included from ./src/better_sqlite3.lzz:11:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/node.h:74:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8.h:24:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-array-buffer.h:12:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-local-handle.h:13:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-handle-base.h:8:
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-internal.h:1256:37: error: a non-type template parameter cannot have type 'ExternalPointerTagRange' (aka 'TagRange<ExternalPointerTag>') before C++20
+npm error  1256 |   template <ExternalPointerTagRange tag_range>
+npm error       |                                     ^
+npm error In file included from ../src/better_sqlite3.cpp:4:
+npm error In file included from ./src/better_sqlite3.lzz:11:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/node.h:74:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8.h:24:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-array-buffer.h:12:
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-local-handle.h:280:5: error: unknown type name 'requires'
+npm error   280 |     requires std::is_base_of_v<T, S>
+npm error       |     ^
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-local-handle.h:280:19: error: non-friend class member 'is_base_of_v' cannot have a qualified name
+npm error   280 |     requires std::is_base_of_v<T, S>
+npm error       |              ~~~~~^
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-local-handle.h:280:19: error: member 'is_base_of_v' declared as a template
+npm error   279 |   template <class S>
+npm error       |   ~~~~~~~~~~~~~~~~~~
+npm error   280 |     requires std::is_base_of_v<T, S>
+npm error       |                   ^
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-local-handle.h:280:19: error: variable template partial specialization of 'is_base_of_v' not in a namespace enclosing '__1'
+npm error /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__type_traits/is_base_of.h:27:50: note: explicitly specialized declaration is here
+npm error    27 | _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_base_of_v = __is_base_of(_Bp, _Dp);
+npm error       |                                                  ^
+npm error In file included from ../src/better_sqlite3.cpp:4:
+npm error In file included from ./src/better_sqlite3.lzz:11:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/node.h:74:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8.h:24:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-array-buffer.h:12:
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-local-handle.h:280:37: error: expected ';' at end of declaration list
+npm error   280 |     requires std::is_base_of_v<T, S>
+npm error       |                                     ^
+npm error       |                                     ;
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-local-handle.h:645:5: error: unknown type name 'requires'
+npm error   645 |     requires std::is_base_of_v<T, S>
+npm error       |     ^
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-local-handle.h:645:19: error: non-friend class member 'is_base_of_v' cannot have a qualified name
+npm error   645 |     requires std::is_base_of_v<T, S>
+npm error       |              ~~~~~^
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-local-handle.h:645:19: error: member 'is_base_of_v' declared as a template
+npm error   644 |   template <class S>
+npm error       |   ~~~~~~~~~~~~~~~~~~
+npm error   645 |     requires std::is_base_of_v<T, S>
+npm error       |                   ^
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-local-handle.h:645:19: error: variable template partial specialization of 'is_base_of_v' not in a namespace enclosing '__1'
+npm error /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__type_traits/is_base_of.h:27:50: note: explicitly specialized declaration is here
+npm error    27 | _LIBCPP_NO_SPECIALIZATIONS inline constexpr bool is_base_of_v = __is_base_of(_Bp, _Dp);
+npm error       |                                                  ^
+npm error In file included from ../src/better_sqlite3.cpp:4:
+npm error In file included from ./src/better_sqlite3.lzz:11:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/node.h:74:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8.h:24:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-array-buffer.h:12:
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-local-handle.h:645:37: error: expected ';' at end of declaration list
+npm error   645 |     requires std::is_base_of_v<T, S>
+npm error       |                                     ^
+npm error       |                                     ;
+npm error In file included from ../src/better_sqlite3.cpp:4:
+npm error In file included from ./src/better_sqlite3.lzz:11:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/node.h:74:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8.h:24:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-array-buffer.h:13:
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-memory-span.h:45:28: error: no member named 'ranges' in namespace 'std'
+npm error    45 | inline constexpr bool std::ranges::enable_view<v8::MemorySpan<T>> = true;
+npm error       |                       ~~~~~^
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-memory-span.h:47:28: error: no member named 'ranges' in namespace 'std'
+npm error    47 | inline constexpr bool std::ranges::enable_borrowed_range<v8::MemorySpan<T>> =
+npm error       |                       ~~~~~^
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-memory-span.h:168:35: error: no type named 'contiguous_iterator_tag' in namespace 'std'; did you mean 'output_iterator_tag'?
+npm error   168 |     using iterator_concept = std::contiguous_iterator_tag;
+npm error       |                              ~~~~~^~~~~~~~~~~~~~~~~~~~~~~
+npm error       |                                   output_iterator_tag
+npm error /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__iterator/iterator_traits.h:70:29: note: 'output_iterator_tag' declared here
+npm error    70 | struct _LIBCPP_TEMPLATE_VIS output_iterator_tag {};
+npm error       |                             ^
+npm error In file included from ../src/better_sqlite3.cpp:4:
+npm error In file included from ./src/better_sqlite3.lzz:11:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/node.h:74:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8.h:24:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-array-buffer.h:14:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-object.h:10:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-maybe.h:11:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/cppgc/internal/conditional-stack-allocated.h:10:
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/cppgc/macros.h:51:1: error: unknown type name 'concept'
+npm error    51 | concept IsStackAllocatedType =
+npm error       | ^
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/cppgc/macros.h:52:5: error: use of undeclared identifier 'requires'
+npm error    52 |     requires { typename T::IsStackAllocatedTypeMarker; };
+npm error       |     ^
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/cppgc/macros.h:52:13: error: expected ';' after top level declarator
+npm error    52 |     requires { typename T::IsStackAllocatedTypeMarker; };
+npm error       |             ^
+npm error       |             ;
+npm error In file included from ../src/better_sqlite3.cpp:4:
+npm error In file included from ./src/better_sqlite3.lzz:11:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/node.h:74:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8.h:24:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-array-buffer.h:14:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-object.h:10:
+npm error In file included from /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/v8-maybe.h:11:
+npm error /Users/hark/Library/Caches/node-gyp/24.12.0/include/node/cppgc/internal/conditional-stack-allocated.h:22:1: error: unknown type name 'concept'
+npm error    22 | concept RequiresStackAllocated =
+npm error       | ^
+npm error fatal error: too many errors emitted, stopping now [-ferror-limit=]
+npm error 20 errors generated.
+npm error make: *** [Release/obj.target/better_sqlite3/src/better_sqlite3.o] Error 1
+npm error gyp ERR! build error 
+npm error gyp ERR! stack Error: `make` failed with exit code: 2
+npm error gyp ERR! stack at ChildProcess.<anonymous> (/Users/hark/.nvm/versions/node/v24.12.0/lib/node_modules/npm/node_modules/node-gyp/lib/build.js:219:23)
+npm error gyp ERR! System Darwin 25.1.0
+npm error gyp ERR! command "/Users/hark/.nvm/versions/node/v24.12.0/bin/node" "/Users/hark/.nvm/versions/node/v24.12.0/lib/node_modules/npm/node_modules/node-gyp/bin/node-gyp.js" "rebuild" "--release"
+npm error gyp ERR! cwd /Users/hark/ssw/automation/nextjs-cve-scanner/repos_temp/llama-link/node_modules/better-sqlite3
+npm error gyp ERR! node -v v24.12.0
+npm error gyp ERR! node-gyp -v v11.4.2
+npm error gyp ERR! not ok
+npm error A complete log of this run can be found in: /Users/hark/.npm/_logs/2025-12-16T03_04_40_485Z-debug-0.log
+[1;33m⚠️  [WARNING][0m   npm install had issues in .
+[0;32m✅ [SUCCESS][0m Lockfiles updated
+[0;34m[INFO][0m Changes detected, proceeding with commit...

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "class-variance-authority": "^0.4.0",
     "clsx": "^1.2.1",
     "lucide-react": "0.105.0-alpha.4",
-    "next": "^13.4.4",
+    "next": "14.2.35",
     "next-themes": "^0.2.1",
     "prettier-plugin-tailwindcss": "^0.3.0",
     "react": "^18.2.0",


### PR DESCRIPTION
## Security Update: Next.js CVE Fixes

This PR fixes critical security vulnerabilities in Next.js:

- **CVE-2025-55184** (High Severity): Denial of Service
- **CVE-2025-55183** (Medium Severity): Source Code Exposure  
- **CVE-2025-67779**: Complete DoS Fix

### Changes
- Updated Next.js to patched version using `npx fix-react2shell-next --fix`
- Works recursively for monorepos

### References
- [Next.js Security Advisory](https://nextjs.org/blog/security-update-2025-12-11)
- [React Blog Post](https://react.dev/blog/2025/12/11/denial-of-service-and-source-code-exposure-in-react-server-components)

### Action Required
- Review and merge to apply security patches
- Deploy to production environments